### PR TITLE
DDCE-537 added code to make H1 xlarge

### DIFF
--- a/app/views/CompanyDetailsView.scala.html
+++ b/app/views/CompanyDetailsView.scala.html
@@ -37,7 +37,7 @@
 
         @components.error_summary(form.errors)
 
-        @components.heading("companyDetails.heading")
+        @components.heading("companyDetails.heading", "heading-xlarge")
 
         <p>@messages("companyDetails.hint")</p>
 

--- a/test/views/CompanyDetailsViewSpec.scala
+++ b/test/views/CompanyDetailsViewSpec.scala
@@ -42,5 +42,7 @@ class CompanyDetailsViewSpec extends QuestionViewBehaviours[CompanyDetails] {
     behave like pageWithTextFields(createViewUsingForm, messageKeyPrefix, routes.CompanyDetailsController.onSubmit(NormalMode).url, "companyName", "companyReferenceNumber")
 
     behave like pageWithBackLink(createView)
+
+    behave like pageWithCorrectHeadingSize(createView)
   }
 }

--- a/test/views/ViewSpecBase.scala
+++ b/test/views/ViewSpecBase.scala
@@ -91,4 +91,8 @@ trait ViewSpecBase extends SpecBase {
       case _ => assert(!radio.hasAttr("checked") && radio.attr("checked") != "checked", s"\n\nElement $id is checked")
     }
   }
+
+  def assertH1HasClass(doc: Document, cssSelector: String, expectedClass: String) = {
+    assert(doc.select(cssSelector).hasClass(expectedClass), s"\n\nElement $cssSelector does not have class $expectedClass")
+  }
 }

--- a/test/views/behaviours/ViewBehaviours.scala
+++ b/test/views/behaviours/ViewBehaviours.scala
@@ -66,4 +66,10 @@ trait ViewBehaviours extends ViewSpecBase {
       }
     }
   }
+  def pageWithCorrectHeadingSize(view: () => HtmlFormat.Appendable) = {
+    "display the correct size of page heading" in {
+      val doc = asDocument(view())
+      assertH1HasClass(doc, "h1", "heading-xlarge")
+    }
+  }
 }


### PR DESCRIPTION
# DDCE-537

##New feature 

Changed H1 size on /enter-company-details to xLarge.
Presented to Vijay Kandhalu
There is only one commit so squashing not done.
Also, Iqra is working on dependency updates already so is not included in this change.
Added unit test to check xLarge H1
There is no change in journey tests. Ran locally, tests are passing successfully.

## PR Suggestions
- Have you looked at the JIRA story to make sure all Acceptance Criteria has been met?
- Have you done a visual check of the changes?
- Is there any still commented or unused code? Lingering printlns?
- Have things been implemented in a complicated way?
- Are the test still over the coverage threshold?
- Does the compiler throw a lot of warnings? 
- Have methods and tests been named clearly?
- Were there any changes in the config? Do changes need to be made in app-config-???


## Checklist PR Raiser
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [ ]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date

## Checklist PR Reviewer
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [x]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date